### PR TITLE
FIX - buffer response

### DIFF
--- a/lib/request-response.js
+++ b/lib/request-response.js
@@ -42,7 +42,7 @@ module.exports = class RequestResponse {
 		try {
 			return JSON.parse(rawBody.toString());
 		} catch(error) {
-			return rawBody;
+			return rawBody.toString();
 		}
 	}
 };

--- a/tests/request.js
+++ b/tests/request.js
@@ -292,13 +292,15 @@ describe('Request Test', () => {
 
 		const url = 'http://test.com';
 
+		const bodyContent = '<h1>test</h1>';
+
 		const response = {
 			code: 200,
-			body: Buffer.from('<h1>test</h1>'),
+			body: Buffer.from(bodyContent),
 			headers: { 'content-type': 'text/html' }
 		};
 
-		const payload = Buffer.from('<form>test</form>', 'utf-8');
+		const payload = Buffer.from(bodyContent, 'utf-8');
 
 		const reqPassThrough = new PassThrough();
 		const writeSpy = sinon.spy(reqPassThrough, 'write');
@@ -319,8 +321,8 @@ describe('Request Test', () => {
 		});
 
 		assert.deepStrictEqual(Request.statusCode, response.code);
-		assert.deepStrictEqual(Request.responseBody, response.body);
-		assert.deepStrictEqual(reqResponse.rawBody, response.body);
+		assert.deepStrictEqual(Request.responseBody, bodyContent);
+		assert.deepStrictEqual(reqResponse.rawBody, payload);
 	});
 
 	it('Should make a get request by default', async () => {


### PR DESCRIPTION
**Descripcion**
Actualmente cuando no puede parsear una respuesta en objeto devuelve en body el buffer que no puede parsear, ademas este buffer ya se devuelve en `rawBody`

**Requisito**
se debe convertir a cadena el buffer mencionado en caso de que no pueda parsearlo a objeto 